### PR TITLE
feat: auto-sync developer role

### DIFF
--- a/frontend/src/pages/ManageSubscription.tsx
+++ b/frontend/src/pages/ManageSubscription.tsx
@@ -130,7 +130,7 @@ const MOCK_BILLING_HISTORY: BillingHistory[] = [
 ];
 
 export default function ManageSubscription() {
-  const { user } = useAuth();
+  const { user, isDeveloper } = useAuth();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
@@ -138,8 +138,7 @@ export default function ManageSubscription() {
   const [selectedPlan, setSelectedPlan] = useState<SubscriptionPlan | null>(null);
   const [billingHistory] = useState<BillingHistory[]>(MOCK_BILLING_HISTORY);
 
-  const isDevAccount = user?.user_metadata?.role === 'developer';
-  const currentPlan = isDevAccount ? 'Ultra' : 'Free';
+  const currentPlan = isDeveloper ? 'Ultra' : 'Free';
   const nextBillingDate = new Date();
   nextBillingDate.setMonth(nextBillingDate.getMonth() + 1);
 
@@ -241,7 +240,7 @@ export default function ManageSubscription() {
                     <h3 className="text-lg font-semibold">{currentPlan} Plan</h3>
                   </div>
                   <p className="text-gray-300">
-                    {isDevAccount ? '1,000,000 tokens per month' : '10,000 tokens per month'}
+                    {isDeveloper ? '1,000,000 tokens per month' : '10,000 tokens per month'}
                   </p>
                 </div>
                 
@@ -251,7 +250,7 @@ export default function ManageSubscription() {
                     <h3 className="text-lg font-semibold">Next Billing</h3>
                   </div>
                   <p className="text-gray-300">
-                    {isDevAccount ? 'No billing required' : nextBillingDate.toLocaleDateString()}
+                    {isDeveloper ? 'No billing required' : nextBillingDate.toLocaleDateString()}
                   </p>
                 </div>
                 
@@ -269,7 +268,7 @@ export default function ManageSubscription() {
       </section>
 
       {/* Available Plans */}
-      {!isDevAccount && (
+      {!isDeveloper && (
         <section className="py-8">
           <div className="container mx-auto px-4">
             <div className="max-w-6xl mx-auto">
@@ -351,7 +350,7 @@ export default function ManageSubscription() {
               {/* Payment Method */}
               <div className="bg-gray-800 rounded-xl p-6">
                 <h2 className="text-2xl font-bold mb-6">Payment Method</h2>
-                {isDevAccount ? (
+                {isDeveloper ? (
                   <div className="text-center py-8">
                     <Crown className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
                     <p className="text-gray-300">No payment method required for Ultra account</p>
@@ -391,7 +390,7 @@ export default function ManageSubscription() {
                     <Edit3 className="w-5 h-5 mr-2" />
                     Update Billing Info
                   </button>
-                  {!isDevAccount && (
+                  {!isDeveloper && (
                     <button 
                       onClick={handleCancelSubscription}
                       className="w-full bg-red-600 hover:bg-red-500 text-white py-3 rounded-lg font-semibold transition-colors flex items-center justify-center"

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -17,13 +17,12 @@ interface TokenUsage {
 
 
 export default function Profile() {
-    const { user, loading: authLoading, signOut, withValidSession } = useAuth();
+    const { user, loading: authLoading, signOut, withValidSession, isDeveloper } = useAuth();
   const navigate = useNavigate();
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>({ total_tokens: 0, recent_activity: [] });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-    const isDevAccount = user?.user_metadata?.role === 'developer';
     const tokensUsed = tokenUsage.total_tokens;
     const tokensRemaining = Math.max(0, TOKEN_LIMIT - tokensUsed);
     const usagePercentage = Math.min((tokensUsed / TOKEN_LIMIT) * 100, 100);
@@ -36,7 +35,7 @@ export default function Profile() {
       }
 
     const fetchUserData = async () => {
-        if (!user || isDevAccount) {
+        if (!user || isDeveloper) {
           setLoading(false);
           return;
         }
@@ -95,7 +94,7 @@ export default function Profile() {
     if (user) {
       fetchUserData();
     }
-    }, [user, authLoading, navigate, isDevAccount, withValidSession]);
+    }, [user, authLoading, navigate, isDeveloper, withValidSession]);
 
   const handleSignOut = async () => {
     try {
@@ -129,9 +128,9 @@ export default function Profile() {
     },
     {
       label: "Account Status",
-      value: isDevAccount ? "Premium" : "Standard",
+      value: isDeveloper ? "Premium" : "Standard",
       icon: Award,
-      color: isDevAccount ? "text-purple-500" : "text-blue-500"
+      color: isDeveloper ? "text-purple-500" : "text-blue-500"
     }
   ];
 
@@ -184,7 +183,7 @@ export default function Profile() {
                 </h1>
                 <p className="text-lg text-gray-300">{user.email}</p>
                 <p className="text-sm text-gray-400 mt-1">
-                  Plan: {isDevAccount ? "Premium" : "Standard"}
+                  Plan: {isDeveloper ? "Premium" : "Standard"}
                 </p>
               </div>
             </motion.div>
@@ -250,7 +249,7 @@ export default function Profile() {
       </section>
 
       {/* Usage Progress (for non-judge accounts) - Keep prompts, tokens, and plan tier */}
-        {!isDevAccount && (
+        {!isDeveloper && (
         <section className="py-8">
           <div className="container mx-auto px-4">
             <div className="max-w-2xl mx-auto">


### PR DESCRIPTION
## Summary
- auto-sync developer role from `developer_accounts` on session and sign-in, updating user metadata
- expose `isDeveloper` via auth context with loading guard and update pages to consume it

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

RLS policy: `SELECT using (auth.email() = email)`

Vercel preview: https://vercel.com/preview

Dev email present in table → shows Premium/Ultra behavior.
Non-dev email → shows Standard/Free behavior.


------
https://chatgpt.com/codex/tasks/task_e_689d09a0a894832aa1c5944afe1391d2