### PR TITLE
Skip token usage fetch for developers

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -34,8 +34,13 @@ export default function Profile() {
         return;
       }
 
+    if (isDeveloper) {
+      setLoading(false);
+      return;
+    }
+
     const fetchUserData = async () => {
-        if (!user || isDeveloper) {
+        if (!user) {
           setLoading(false);
           return;
         }


### PR DESCRIPTION
## Summary
- avoid token usage fetch for developer accounts by exiting the profile load early
- remove redundant developer check from user data fetch
