### PR TITLE
Fix developer account role checks and add RLS policy

### DIFF
--- a/supabase/migrations/20250607120000_developer_accounts.sql
+++ b/supabase/migrations/20250607120000_developer_accounts.sql
@@ -1,0 +1,24 @@
+/*
+  # Developer accounts table and access policy
+
+  1. New Tables
+    - developer_accounts
+      - email text primary key
+      - created_at timestamptz default now()
+
+  2. Security
+    - Enable RLS
+    - Policy for authenticated users to read their own row
+*/
+
+create table if not exists developer_accounts (
+  email text primary key,
+  created_at timestamptz default now()
+);
+
+alter table developer_accounts enable row level security;
+
+create policy "Users can read own developer account"
+  on developer_accounts for select
+  to authenticated
+  using (auth.jwt() ->> 'email' = email);


### PR DESCRIPTION
## Summary
- add RLS policy and table migration for `developer_accounts`
- prevent repeated developer role fetches and handle 404/406 gracefully
- stabilize session validation to avoid render loops and reset dev flag on sign-out
