### PR TITLE
refactor: unify developer checks

### DIFF
--- a/frontend/src/components/DemoNavbar.tsx
+++ b/frontend/src/components/DemoNavbar.tsx
@@ -5,7 +5,7 @@ import TokenDisplay from './TokenDisplay';
 
   interface DemoNavbarProps {
     user: { email: string | undefined; id: string };
-    isDevAccount: boolean;
+    isDeveloper: boolean;
     tokenUsage: number;
     isTokenLimitReached: boolean;
     mobileMenuOpen: boolean;
@@ -15,7 +15,7 @@ import TokenDisplay from './TokenDisplay';
 
   export default function DemoNavbar({
     user,
-    isDevAccount,
+    isDeveloper,
     tokenUsage,
     isTokenLimitReached,
     mobileMenuOpen,
@@ -41,7 +41,7 @@ import TokenDisplay from './TokenDisplay';
         
         <div className="flex items-center space-x-2 sm:space-x-4">
             <TokenDisplay
-              isDevAccount={isDevAccount}
+              isDeveloper={isDeveloper}
               tokenUsage={tokenUsage}
               isTokenLimitReached={isTokenLimitReached}
             />

--- a/frontend/src/components/TokenDisplay.tsx
+++ b/frontend/src/components/TokenDisplay.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { TOKEN_LIMIT } from '../constants';
 
 interface TokenDisplayProps {
-  isDevAccount: boolean;
+  isDeveloper: boolean;
   tokenUsage: number;
   isTokenLimitReached: boolean;
 }
 
-const TokenDisplay = React.memo(({ 
-  isDevAccount,
+const TokenDisplay = React.memo(({
+  isDeveloper,
   tokenUsage,
   isTokenLimitReached
 }: TokenDisplayProps) => {
-  if (isDevAccount) {
+  if (isDeveloper) {
     return (
       <div className="rounded-lg px-3 py-1 text-sm bg-green-500/20 border border-green-500/30">
         <span className="text-green-400 font-semibold">Unlimited</span>

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -41,7 +41,6 @@ interface SimulationResponse {
 interface User {
   email: string | undefined;
   id: string;
-  user_metadata?: { role?: string };
 }
 
 const SUBJECTS = ["Physics", "Biology", "Computer Science"] as const;
@@ -611,7 +610,13 @@ const SimulationIframe = React.memo(
 );
 
 export default function Demo(): JSX.Element {
-  const { user, loading: authLoading, error: authError, signOut } = useAuth();
+  const {
+    user,
+    loading: authLoading,
+    error: authError,
+    signOut,
+    isDeveloper,
+  } = useAuth();
   const [subject, setSubject] = useState<SubjectType>("Physics");
   const [prompt, setPrompt] = useState<string>(
     "Show how a pendulum behaves under the influence of gravity and explain the energy transformations during its swing"
@@ -627,13 +632,9 @@ export default function Demo(): JSX.Element {
   const [contentWarningMessage, setContentWarningMessage] =
     useState<string>("");
 
-  const isDevAccount = useMemo(
-    () => user?.user_metadata?.role === "developer",
-    [user?.user_metadata?.role]
-  );
   const isTokenLimitReached = useMemo(
-    () => !isDevAccount && tokenUsage >= TOKEN_LIMIT,
-    [isDevAccount, tokenUsage]
+    () => !isDeveloper && tokenUsage >= TOKEN_LIMIT,
+    [isDeveloper, tokenUsage]
   );
   const tokensRemaining = useMemo(
     () => Math.max(0, TOKEN_LIMIT - tokenUsage),
@@ -641,7 +642,7 @@ export default function Demo(): JSX.Element {
   );
 
   const fetchTokenUsage = useCallback(async () => {
-    if (!user || isDevAccount) return;
+    if (!user || isDeveloper) return;
 
     try {
       const { data: sessionData, error: sessionError } =
@@ -678,7 +679,7 @@ export default function Demo(): JSX.Element {
       console.warn("Failed to fetch token usage:", error);
       setTokenUsage(0);
     }
-  }, [user, isDevAccount]);
+  }, [user, isDeveloper]);
 
   useEffect(() => {
     if (user && !authLoading) {
@@ -788,7 +789,7 @@ export default function Demo(): JSX.Element {
       subject,
       isTokenLimitReached,
       tokenUsage,
-      isDevAccount,
+      isDeveloper,
       fetchTokenUsage,
     ]
   );
@@ -903,7 +904,7 @@ export default function Demo(): JSX.Element {
       <div className="h-screen bg-gray-900 text-white overflow-hidden flex flex-col">
         <DemoNavbar
           user={demoUser}
-          isDevAccount={isDevAccount}
+          isDeveloper={isDeveloper}
           tokenUsage={tokenUsage}
           isTokenLimitReached={isTokenLimitReached}
           mobileMenuOpen={mobileMenuOpen}
@@ -927,7 +928,7 @@ export default function Demo(): JSX.Element {
                   />
                 )}
 
-                {!isDevAccount && isTokenLimitReached && (
+                {!isDeveloper && isTokenLimitReached && (
                   <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-2">
                     <div className="flex items-center space-x-1 mb-1">
                       <AlertTriangle className="w-3 h-3 text-red-400" />
@@ -941,7 +942,7 @@ export default function Demo(): JSX.Element {
                   </div>
                 )}
 
-                {!isDevAccount &&
+                {!isDeveloper &&
                   !isTokenLimitReached &&
                   tokenUsage > TOKEN_LIMIT * 0.8 && (
                     <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-2">


### PR DESCRIPTION
## Summary
- route developer status solely from AuthProvider's `isDeveloper`
- pass `isDeveloper` through Demo navbar and token display
- compute token limits based on unified `isDeveloper` flag