### PR TITLE
Refactor Demo page into modular components

### DIFF
--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Loader2 } from "lucide-react";
+
+interface LoadingSpinnerProps {
+  size?: "small" | "default" | "large";
+  text?: string;
+}
+
+const sizeClasses = {
+  small: "w-4 h-4",
+  default: "w-8 h-8",
+  large: "w-12 h-12",
+} as const;
+
+const LoadingSpinner = React.memo(
+  ({ size = "default", text }: LoadingSpinnerProps) => (
+    <div className="flex flex-col items-center space-y-2">
+      <Loader2 className={`${sizeClasses[size]} text-blue-500 animate-spin`} />
+      {text && <div className="text-gray-700 font-medium text-sm">{text}</div>}
+    </div>
+  )
+);
+
+export default LoadingSpinner;

--- a/frontend/src/components/demo/ContentWarning.tsx
+++ b/frontend/src/components/demo/ContentWarning.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ShieldAlert } from "lucide-react";
+
+interface ContentWarningProps {
+  warningMessage: string;
+  onDismiss: () => void;
+}
+
+const ContentWarning = React.memo(({ warningMessage, onDismiss }: ContentWarningProps) => (
+  <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-3">
+    <div className="flex items-start space-x-2">
+      <ShieldAlert className="w-4 h-4 text-yellow-600 mt-0.5 flex-shrink-0" />
+      <div className="flex-1">
+        <h4 className="text-xs font-semibold text-yellow-900 mb-1">
+          Content Notice
+        </h4>
+        <p className="text-xs text-yellow-700 mb-2">{warningMessage}</p>
+        <button
+          onClick={onDismiss}
+          className="text-xs bg-yellow-600 hover:bg-yellow-700 text-white px-2 py-1 rounded transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    </div>
+  </div>
+));
+
+export default ContentWarning;

--- a/frontend/src/components/demo/DemoErrorBoundary.tsx
+++ b/frontend/src/components/demo/DemoErrorBoundary.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from "react";
+
+interface DemoErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode;
+}
+
+const DemoErrorBoundary = ({ children, fallback }: DemoErrorBoundaryProps) => {
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    const handleError = () => setHasError(true);
+    window.addEventListener("error", handleError);
+    return () => window.removeEventListener("error", handleError);
+  }, []);
+
+  if (hasError) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+};
+
+export default React.memo(DemoErrorBoundary);

--- a/frontend/src/components/demo/ErrorBanner.tsx
+++ b/frontend/src/components/demo/ErrorBanner.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+
+interface ErrorBannerProps {
+  error: string;
+  onDismiss: () => void;
+}
+
+const ErrorBanner = React.memo(({ error, onDismiss }: ErrorBannerProps) => (
+  <div className="bg-red-500/10 border border-red-500/20 rounded-md p-2">
+    <div className="flex items-start space-x-1">
+      <AlertTriangle className="w-3 h-3 text-red-400 mt-0.5 flex-shrink-0" />
+      <div className="flex-1">
+        <div className="text-red-400 font-medium text-xs">Error</div>
+        <div className="text-red-300 text-xs mt-1 break-words leading-tight">
+          {error}
+        </div>
+        <button
+          onClick={onDismiss}
+          className="text-red-400 hover:text-red-300 text-xs mt-1 underline"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  </div>
+));
+
+export default ErrorBanner;

--- a/frontend/src/components/demo/FollowUpBox.tsx
+++ b/frontend/src/components/demo/FollowUpBox.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { MessageSquare, Send } from "lucide-react";
+
+interface FollowUpBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  disabled: boolean;
+}
+
+const FollowUpBox = React.memo(
+  ({ value, onChange, onSubmit, disabled }: FollowUpBoxProps) => (
+    <div className="pt-2 border-t border-gray-700">
+      <div className="flex items-center space-x-1 mb-1">
+        <MessageSquare className="w-3 h-3 text-blue-400" />
+        <label className="text-xs font-medium text-gray-300">Follow-up</label>
+      </div>
+      <div className="flex space-x-1 mb-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Feature coming soon..."
+          disabled={disabled}
+          className="flex-1 bg-gray-700 border border-gray-600 rounded-md px-2 py-1 text-white text-xs focus:ring-1 focus:ring-blue-500 focus:border-transparent transition-colors placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"
+          onKeyPress={(e) => e.key === "Enter" && onSubmit()}
+        />
+        <button
+          onClick={onSubmit}
+          disabled={disabled}
+          className="bg-gray-600 text-white px-2 py-1 rounded-md transition-colors flex items-center disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Send className="w-3 h-3" />
+        </button>
+      </div>
+      <p className="text-xs text-gray-500 italic">
+        Follow-up feature is still being worked on
+      </p>
+    </div>
+  )
+);
+
+export default FollowUpBox;

--- a/frontend/src/components/demo/PromptInput.tsx
+++ b/frontend/src/components/demo/PromptInput.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { SubjectType } from "../../constants/subjects";
+
+interface PromptInputProps {
+  subject: SubjectType;
+  prompt: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+}
+
+const PromptInput = React.memo(
+  ({ subject, prompt, onChange, disabled }: PromptInputProps) => (
+    <div>
+      <label className="block text-sm font-medium text-gray-300 mb-1">
+        Educational Prompt
+      </label>
+      <textarea
+        value={prompt}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={`Describe a ${subject.toLowerCase()} concept to visualize...`}
+        disabled={disabled}
+        className="w-full bg-gray-700 border border-gray-600 rounded-md px-2 py-2 text-white h-28 resize-none text-sm focus:ring-1 focus:ring-yellow-500 focus:border-transparent transition-colors placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"
+      />
+      <div className="text-xs text-gray-400 mt-1">
+        {prompt.length}/500 • {subject} educational content
+      </div>
+    </div>
+  )
+);
+
+export default PromptInput;

--- a/frontend/src/components/demo/RunButton.tsx
+++ b/frontend/src/components/demo/RunButton.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Play, Loader2, AlertTriangle } from "lucide-react";
+
+interface RunButtonProps {
+  onClick: () => void;
+  disabled: boolean;
+  isLoading: boolean;
+  isTokenLimitReached: boolean;
+}
+
+const RunButton = React.memo(
+  ({ onClick, disabled, isLoading, isTokenLimitReached }: RunButtonProps) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="w-full bg-yellow-500 text-black py-2 rounded-md hover:bg-yellow-400 transition-colors flex items-center justify-center space-x-1 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm disabled:bg-gray-600 disabled:text-gray-400"
+    >
+      {isLoading ? (
+        <>
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>Creating...</span>
+        </>
+      ) : isTokenLimitReached ? (
+        <>
+          <AlertTriangle className="w-3 h-3" />
+          <span>Limit</span>
+        </>
+      ) : (
+        <>
+          <Play className="w-3 h-3" />
+          <span>Generate</span>
+        </>
+      )}
+    </button>
+  )
+);
+
+export default RunButton;

--- a/frontend/src/components/demo/SimulationFrame.tsx
+++ b/frontend/src/components/demo/SimulationFrame.tsx
@@ -1,0 +1,223 @@
+import React, { useMemo } from "react";
+import { SimulationResponse } from "../../types/demo";
+
+interface SimulationFrameProps {
+  simulationData: SimulationResponse;
+}
+
+const SimulationFrame = React.memo(({ simulationData }: SimulationFrameProps) => {
+  const iframeContent = useMemo(
+    () => `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'none';">
+      <title>MindRender Simulation</title>
+      <style>
+        * {
+          margin: 0;
+          padding: 0;
+          box-sizing: border-box;
+        }
+        html, body {
+          height: 100%;
+          width: 100%;
+          overflow: hidden;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+          background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        canvas {
+          border: 2px solid #e5e7eb;
+          border-radius: 12px;
+          background: white;
+          box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+          display: block !important;
+          margin: 0 auto;
+          max-width: 100%;
+          max-height: 100%;
+          cursor: pointer;
+        }
+
+        .status {
+          position: fixed;
+          top: 15px;
+          right: 15px;
+          padding: 6px 12px;
+          border-radius: 6px;
+          font-size: 11px;
+          font-weight: 600;
+          z-index: 1000;
+          backdrop-filter: blur(8px);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+          transition: all 0.3s ease;
+          opacity: 0.9;
+        }
+        .status.loading {
+          background: rgba(59, 130, 246, 0.15);
+          color: #1e40af;
+          border-color: rgba(59, 130, 246, 0.4);
+        }
+        .status.success {
+          background: rgba(16, 185, 129, 0.15);
+          color: #059669;
+          border-color: rgba(16, 185, 129, 0.4);
+        }
+        .status.error {
+          background: rgba(239, 68, 68, 0.15);
+          color: #dc2626;
+          border-color: rgba(239, 68, 68, 0.4);
+        }
+        .status.warning {
+          background: rgba(245, 158, 11, 0.15);
+          color: #d97706;
+          border-color: rgba(245, 158, 11, 0.4);
+        }
+      </style>
+    </head>
+    <body>
+      <div class="status ${
+        simulationData.contentWarning ? "warning" : "loading"
+      }" id="status">${
+        simulationData.contentWarning ? "Content Notice" : "Initializing..."
+      }</div>
+
+      ${simulationData.canvasHtml}
+
+      <script>
+        const statusEl = document.getElementById('status');
+
+        function resizeCanvas() {
+          const canvas = document.querySelector('canvas');
+          if (!canvas) return;
+
+          const originalWidth = canvas.width || 800;
+          const originalHeight = canvas.height || 600;
+          const aspectRatio = originalWidth / originalHeight;
+
+          const availableWidth = window.innerWidth * 0.92;
+          const availableHeight = window.innerHeight * 0.92;
+
+          let newWidth, newHeight;
+
+          if (availableWidth / aspectRatio <= availableHeight) {
+            newWidth = availableWidth;
+            newHeight = availableWidth / aspectRatio;
+          } else {
+            newHeight = availableHeight;
+            newWidth = availableHeight * aspectRatio;
+          }
+
+          newWidth = Math.max(newWidth, 400);
+          newHeight = Math.max(newHeight, 300);
+
+          canvas.width = Math.floor(newWidth);
+          canvas.height = Math.floor(newHeight);
+
+          canvas.style.width = Math.floor(newWidth) + 'px';
+          canvas.style.height = Math.floor(newHeight) + 'px';
+
+          console.log('Canvas resized to:', Math.floor(newWidth) + 'x' + Math.floor(newHeight));
+        }
+
+        window.onerror = function(message, source, lineno, colno, error) {
+          console.error('Simulation Error:', message, 'Line:', lineno);
+          if (statusEl) {
+            statusEl.className = 'status error';
+            statusEl.textContent = 'Script Error';
+          }
+          return true;
+        };
+
+        setTimeout(() => {
+          const canvas = document.querySelector('canvas');
+          if (canvas) {
+            console.log('Canvas found, original size:', canvas.width + 'x' + canvas.height);
+
+            resizeCanvas();
+
+            canvas.style.display = 'block';
+            canvas.style.margin = '0 auto';
+            canvas.style.cursor = 'pointer';
+
+            if (statusEl && !${simulationData.contentWarning}) {
+              statusEl.className = 'status loading';
+              statusEl.textContent = 'Loading simulation...';
+            }
+
+            executeSimulation();
+          } else {
+            console.error('Canvas element not found');
+            if (statusEl) {
+              statusEl.className = 'status error';
+              statusEl.textContent = 'Canvas not found';
+            }
+          }
+        }, 100);
+
+        function executeSimulation() {
+          try {
+            ${simulationData.jsCode}
+
+            ${
+              !simulationData.contentWarning
+                ? `
+            setTimeout(() => {
+              if (statusEl) {
+                statusEl.className = 'status success';
+                statusEl.textContent = 'Interactive';
+                setTimeout(() => {
+                  statusEl.style.opacity = '0.6';
+                }, 2000);
+              }
+            }, 1000);
+            `
+                : ""
+            }
+
+          } catch (error) {
+            console.error('Execution Error:', error);
+            if (statusEl) {
+              statusEl.className = 'status error';
+              statusEl.textContent = 'Error: ' + error.message;
+            }
+          }
+        }
+
+        window.addEventListener('resize', () => {
+          setTimeout(resizeCanvas, 100);
+        });
+      </script>
+    </body>
+    </html>
+  `,
+    [
+      simulationData.canvasHtml,
+      simulationData.jsCode,
+      simulationData.contentWarning,
+    ]
+  );
+
+  return (
+    <iframe
+      className="w-full h-full border-0"
+      title="Interactive Simulation"
+      sandbox="allow-scripts"
+      scrolling="no"
+      srcDoc={iframeContent}
+      style={{
+        overflow: "hidden",
+        border: "none",
+        width: "100%",
+        height: "100%",
+      }}
+    />
+  );
+});
+
+export default SimulationFrame;

--- a/frontend/src/components/demo/SubjectSelector.tsx
+++ b/frontend/src/components/demo/SubjectSelector.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { SUBJECTS, SUBJECT_INFO, SubjectType } from "../../constants/subjects";
+
+interface SubjectSelectorProps {
+  subject: SubjectType;
+  onChange: (value: SubjectType) => void;
+  disabled: boolean;
+}
+
+const SubjectSelector = React.memo(
+  ({ subject, onChange, disabled }: SubjectSelectorProps) => (
+    <div>
+      <label className="block text-sm font-medium text-gray-300 mb-2">
+        Subject Area
+      </label>
+      <select
+        value={subject}
+        onChange={(e) => onChange(e.target.value as SubjectType)}
+        disabled={disabled}
+        className="w-full bg-gray-700 border border-gray-600 rounded-md px-2 py-2 text-white text-sm focus:ring-1 focus:ring-yellow-500 focus:border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {SUBJECTS.map((subj) => (
+          <option key={subj} value={subj}>
+            {subj}
+          </option>
+        ))}
+      </select>
+
+      <div className="mt-2 p-2 bg-gray-600/30 rounded-md">
+        <div className="flex items-center space-x-2 mb-1">
+          {React.createElement(SUBJECT_INFO[subject].icon, {
+            className: "w-4 h-4 text-yellow-400",
+          })}
+          <span className="text-xs font-medium text-gray-300">{subject}</span>
+        </div>
+        <p className="text-xs text-gray-400 mb-2">
+          {SUBJECT_INFO[subject].description}
+        </p>
+        <div className="text-xs text-gray-500">
+          <strong>Try:</strong> {SUBJECT_INFO[subject].examples.join(", ")}
+        </div>
+      </div>
+    </div>
+  )
+);
+
+export default SubjectSelector;

--- a/frontend/src/components/demo/TokenNotices.tsx
+++ b/frontend/src/components/demo/TokenNotices.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+import { TOKEN_LIMIT } from "../../constants";
+
+interface TokenNoticesProps {
+  isDeveloper: boolean;
+  isTokenLimitReached: boolean;
+  tokenUsage: number;
+  tokensRemaining: number;
+}
+
+const TokenNotices = React.memo(
+  ({ isDeveloper, isTokenLimitReached, tokenUsage, tokensRemaining }: TokenNoticesProps) => (
+    <>
+      {!isDeveloper && isTokenLimitReached && (
+        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-2">
+          <div className="flex items-center space-x-1 mb-1">
+            <AlertTriangle className="w-3 h-3 text-red-400" />
+            <div className="text-red-400 font-medium text-xs">Token Limit</div>
+          </div>
+          <div className="text-red-300 text-xs">
+            Used {tokenUsage}/{TOKEN_LIMIT} tokens.
+          </div>
+        </div>
+      )}
+
+      {!isDeveloper && !isTokenLimitReached && tokenUsage > TOKEN_LIMIT * 0.8 && (
+        <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-2">
+          <div className="flex items-center space-x-1 mb-1">
+            <AlertTriangle className="w-3 h-3 text-yellow-400" />
+            <div className="text-yellow-400 font-medium text-xs">Warning</div>
+          </div>
+          <div className="text-yellow-300 text-xs">{tokensRemaining} tokens left.</div>
+        </div>
+      )}
+    </>
+  )
+);
+
+export default TokenNotices;

--- a/frontend/src/constants/subjects.ts
+++ b/frontend/src/constants/subjects.ts
@@ -1,0 +1,46 @@
+import React from "react";
+import { Atom, Dna, Cpu } from "lucide-react";
+
+export const SUBJECTS = ["Physics", "Biology", "Computer Science"] as const;
+export type SubjectType = (typeof SUBJECTS)[number];
+
+export const SUBJECT_INFO: Record<
+  SubjectType,
+  {
+    icon: React.ComponentType<{ className?: string }>;
+    description: string;
+    examples: string[];
+  }
+> = {
+  Physics: {
+    icon: Atom,
+    description: "Interactive physics simulations with real-time controls",
+    examples: [
+      "pendulum motion",
+      "wave interference",
+      "electromagnetic fields",
+      "thermodynamics",
+    ],
+  },
+  Biology: {
+    icon: Dna,
+    description: "Dynamic biological process visualizations",
+    examples: [
+      "cell division",
+      "photosynthesis",
+      "genetic inheritance",
+      "ecosystem dynamics",
+    ],
+  },
+  "Computer Science": {
+    icon: Cpu,
+    description: "Algorithm and data structure visualizations",
+    examples: [
+      "sorting algorithms",
+      "binary trees",
+      "pathfinding",
+      "recursive functions",
+    ],
+  },
+};
+

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -1,90 +1,22 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useMemo,
-} from "react";
-import DOMPurify from "dompurify";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { useAuth } from "../contexts/AuthProvider";
 import { supabase } from "../lib/supabaseClient";
 import { TOKEN_LIMIT } from "../constants";
-import {
-  Play,
-  LogOut,
-  Send,
-  Loader2,
-  BookOpen,
-  Monitor,
-  MessageSquare,
-  AlertTriangle,
-  Menu,
-  X,
-  ShieldAlert,
-  Cpu,
-  Atom,
-  Dna,
-} from "lucide-react";
+import { SUBJECT_INFO, SubjectType } from "../constants/subjects";
+import { SimulationResponse, User } from "../types/demo";
+import { LogOut, Monitor, BookOpen } from "lucide-react";
 import DemoNavbar from "../components/DemoNavbar";
-
-interface SimulationResponse {
-  canvasHtml: string;
-  jsCode: string;
-  explanation: string;
-  usage?: {
-    totalTokens: number;
-  };
-  contentWarning?: boolean;
-  warningMessage?: string;
-}
-
-interface User {
-  email: string | undefined;
-  id: string;
-}
-
-const SUBJECTS = ["Physics", "Biology", "Computer Science"] as const;
-type SubjectType = (typeof SUBJECTS)[number];
-
-const SUBJECT_INFO: Record<
-  SubjectType,
-  {
-    icon: React.ComponentType<{ className?: string }>;
-    description: string;
-    examples: string[];
-  }
-> = {
-  Physics: {
-    icon: Atom,
-    description: "Interactive physics simulations with real-time controls",
-    examples: [
-      "pendulum motion",
-      "wave interference",
-      "electromagnetic fields",
-      "thermodynamics",
-    ],
-  },
-  Biology: {
-    icon: Dna,
-    description: "Dynamic biological process visualizations",
-    examples: [
-      "cell division",
-      "photosynthesis",
-      "genetic inheritance",
-      "ecosystem dynamics",
-    ],
-  },
-  "Computer Science": {
-    icon: Cpu,
-    description: "Algorithm and data structure visualizations",
-    examples: [
-      "sorting algorithms",
-      "binary trees",
-      "pathfinding",
-      "recursive functions",
-    ],
-  },
-};
+import DemoErrorBoundary from "../components/demo/DemoErrorBoundary";
+import LoadingSpinner from "../components/LoadingSpinner";
+import SubjectSelector from "../components/demo/SubjectSelector";
+import PromptInput from "../components/demo/PromptInput";
+import RunButton from "../components/demo/RunButton";
+import TokenNotices from "../components/demo/TokenNotices";
+import SimulationFrame from "../components/demo/SimulationFrame";
+import ExplanationPanel from "../components/demo/ExplanationPanel";
+import ErrorBanner from "../components/demo/ErrorBanner";
+import ContentWarning from "../components/demo/ContentWarning";
+import FollowUpBox from "../components/demo/FollowUpBox";
 
 const validatePromptClient = (
   prompt: string,
@@ -152,462 +84,6 @@ const validatePromptClient = (
 
   return { isValid: true };
 };
-
-const ErrorBoundary: React.FC<{
-  children: React.ReactNode;
-  fallback: React.ReactNode;
-}> = ({ children, fallback }) => {
-  const [hasError, setHasError] = useState(false);
-
-  useEffect(() => {
-    const handleError = () => setHasError(true);
-    window.addEventListener("error", handleError);
-    return () => window.removeEventListener("error", handleError);
-  }, []);
-
-  if (hasError) {
-    return <>{fallback}</>;
-  }
-
-  return <>{children}</>;
-};
-
-const LoadingSpinner = React.memo(
-  ({
-    size = "default",
-    text,
-  }: {
-    size?: "small" | "default" | "large";
-    text?: string;
-  }) => {
-    const sizeClasses = {
-      small: "w-4 h-4",
-      default: "w-8 h-8",
-      large: "w-12 h-12",
-    };
-
-    return (
-      <div className="flex flex-col items-center space-y-2">
-        <Loader2
-          className={`${sizeClasses[size]} text-blue-500 animate-spin`}
-        />
-        {text && (
-          <div className="text-gray-700 font-medium text-sm">{text}</div>
-        )}
-      </div>
-    );
-  }
-);
-
-const FormattedExplanation = React.memo(
-  ({ explanation }: { explanation: string }) => {
-    const [isExpanded, setIsExpanded] = useState(false);
-
-    const { truncatedContent, fullContent, needsTruncation } = useMemo(() => {
-      if (!explanation)
-        return {
-          truncatedContent: "",
-          fullContent: "",
-          needsTruncation: false,
-        };
-
-      const formatContent = (text: string) => {
-        return text
-          .replace(/\*\*(.*?)\*\*/g, '<h3 class="explanation-heading">$1</h3>')
-          .replace(/^- (.*$)/gim, '<li class="explanation-bullet">$1</li>')
-          .replace(/^\* (.*$)/gim, '<li class="explanation-bullet">$1</li>')
-          .replace(/^• (.*$)/gim, '<li class="explanation-bullet">$1</li>')
-          .split("\n")
-          .map((line) => {
-            const trimmed = line.trim();
-            if (trimmed.startsWith("<h3") || trimmed.startsWith("<li"))
-              return trimmed;
-            if (trimmed) return `<p class="explanation-text">${trimmed}</p>`;
-            return "";
-          })
-          .filter(Boolean)
-          .join("");
-      };
-
-      const words = explanation.split(" ");
-      const wordLimit = 60;
-      const needsTruncation = words.length > wordLimit;
-
-      const truncatedText = needsTruncation
-        ? words.slice(0, wordLimit).join(" ") + "..."
-        : explanation;
-
-      return {
-        truncatedContent: DOMPurify.sanitize(formatContent(truncatedText)),
-        fullContent: DOMPurify.sanitize(formatContent(explanation)),
-        needsTruncation,
-      };
-    }, [explanation]);
-
-    return (
-      <div className="space-y-2 h-full overflow-y-auto">
-        <style>{`
-        .explanation-heading {
-          font-size: 16px;
-          font-weight: 700;
-          color: #1f2937;
-          margin: 8px 0 3px 0;
-          padding-bottom: 2px;
-          border-bottom: 2px solid #3b82f6;
-          display: inline-block;
-          line-height: 1.2;
-          word-wrap: break-word;
-          overflow-wrap: break-word;
-        }
-        .explanation-heading:first-child {
-          margin-top: 0;
-        }
-        .explanation-bullet {
-          list-style: none;
-          position: relative;
-          padding-left: 14px;
-          margin: 2px 0;
-          line-height: 1.3;
-          color: #374151;
-          font-size: 14px;
-          word-wrap: break-word;
-          overflow-wrap: break-word;
-          hyphens: auto;
-        }
-        .explanation-bullet:before {
-          content: "•";
-          color: #3b82f6;
-          font-weight: bold;
-          position: absolute;
-          left: 0;
-          font-size: 12px;
-        }
-        .explanation-text {
-          margin: 3px 0;
-          line-height: 1.3;
-          color: #4b5563;
-          font-size: 14px;
-          word-wrap: break-word;
-          overflow-wrap: break-word;
-          hyphens: auto;
-        }
-      `}</style>
-
-        <div
-          className="explanation-content"
-          dangerouslySetInnerHTML={{
-            __html: isExpanded ? fullContent : truncatedContent,
-          }}
-        />
-
-        {needsTruncation && (
-          <div className="mt-2">
-            <button
-              onClick={() => setIsExpanded(!isExpanded)}
-              className="text-blue-600 hover:text-blue-800 text-xs font-medium underline focus:outline-none focus:ring-1 focus:ring-blue-500 focus:ring-opacity-50 rounded"
-            >
-              {isExpanded ? "Show Less" : "Read More"}
-            </button>
-          </div>
-        )}
-      </div>
-    );
-  }
-);
-
-const ContentWarningDisplay = React.memo(
-  ({
-    warningMessage,
-    onDismiss,
-  }: {
-    warningMessage: string;
-    onDismiss: () => void;
-  }) => {
-    return (
-      <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-3">
-        <div className="flex items-start space-x-2">
-          <ShieldAlert className="w-4 h-4 text-yellow-600 mt-0.5 flex-shrink-0" />
-          <div className="flex-1">
-            <h4 className="text-xs font-semibold text-yellow-900 mb-1">
-              Content Notice
-            </h4>
-            <p className="text-xs text-yellow-700 mb-2">{warningMessage}</p>
-            <button
-              onClick={onDismiss}
-              className="text-xs bg-yellow-600 hover:bg-yellow-700 text-white px-2 py-1 rounded transition-colors"
-            >
-              Try Again
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-);
-
-const SubjectSelector = React.memo(
-  ({
-    subject,
-    onChange,
-    disabled,
-  }: {
-    subject: SubjectType;
-    onChange: (value: SubjectType) => void;
-    disabled: boolean;
-  }) => {
-    return (
-      <div>
-        <label className="block text-sm font-medium text-gray-300 mb-2">
-          Subject Area
-        </label>
-        <select
-          value={subject}
-          onChange={(e) => onChange(e.target.value as SubjectType)}
-          disabled={disabled}
-          className="w-full bg-gray-700 border border-gray-600 rounded-md px-2 py-2 text-white text-sm focus:ring-1 focus:ring-yellow-500 focus:border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {SUBJECTS.map((subj) => (
-            <option key={subj} value={subj}>
-              {subj}
-            </option>
-          ))}
-        </select>
-
-        <div className="mt-2 p-2 bg-gray-600/30 rounded-md">
-          <div className="flex items-center space-x-2 mb-1">
-            {React.createElement(SUBJECT_INFO[subject].icon, {
-              className: "w-4 h-4 text-yellow-400",
-            })}
-            <span className="text-xs font-medium text-gray-300">{subject}</span>
-          </div>
-          <p className="text-xs text-gray-400 mb-2">
-            {SUBJECT_INFO[subject].description}
-          </p>
-          <div className="text-xs text-gray-500">
-            <strong>Try:</strong> {SUBJECT_INFO[subject].examples.join(", ")}
-          </div>
-        </div>
-      </div>
-    );
-  }
-);
-
-const SimulationIframe = React.memo(
-  ({ simulationData }: { simulationData: SimulationResponse }) => {
-    const iframeContent = useMemo(
-      () => `
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'none';">
-      <title>MindRender Simulation</title>
-      <style>
-        * {
-          margin: 0;
-          padding: 0;
-          box-sizing: border-box;
-        }
-        html, body {
-          height: 100%;
-          width: 100%;
-          overflow: hidden;
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-          background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-        
-        canvas {
-          border: 2px solid #e5e7eb;
-          border-radius: 12px;
-          background: white;
-          box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-          display: block !important;
-          margin: 0 auto;
-          max-width: 100%;
-          max-height: 100%;
-          cursor: pointer;
-        }
-        
-        .status {
-          position: fixed;
-          top: 15px;
-          right: 15px;
-          padding: 6px 12px;
-          border-radius: 6px;
-          font-size: 11px;
-          font-weight: 600;
-          z-index: 1000;
-          backdrop-filter: blur(8px);
-          border: 1px solid rgba(255, 255, 255, 0.3);
-          transition: all 0.3s ease;
-          opacity: 0.9;
-        }
-        .status.loading {
-          background: rgba(59, 130, 246, 0.15);
-          color: #1e40af;
-          border-color: rgba(59, 130, 246, 0.4);
-        }
-        .status.success {
-          background: rgba(16, 185, 129, 0.15);
-          color: #059669;
-          border-color: rgba(16, 185, 129, 0.4);
-        }
-        .status.error {
-          background: rgba(239, 68, 68, 0.15);
-          color: #dc2626;
-          border-color: rgba(239, 68, 68, 0.4);
-        }
-        .status.warning {
-          background: rgba(245, 158, 11, 0.15);
-          color: #d97706;
-          border-color: rgba(245, 158, 11, 0.4);
-        }
-      </style>
-    </head>
-    <body>
-      <div class="status ${
-        simulationData.contentWarning ? "warning" : "loading"
-      }" id="status">${
-        simulationData.contentWarning ? "Content Notice" : "Initializing..."
-      }</div>
-      
-      ${simulationData.canvasHtml}
-      
-      <script>
-        const statusEl = document.getElementById('status');
-        
-        function resizeCanvas() {
-          const canvas = document.querySelector('canvas');
-          if (!canvas) return;
-          
-          const originalWidth = canvas.width || 800;
-          const originalHeight = canvas.height || 600;
-          const aspectRatio = originalWidth / originalHeight;
-          
-          const availableWidth = window.innerWidth * 0.92;
-          const availableHeight = window.innerHeight * 0.92;
-          
-          let newWidth, newHeight;
-          
-          if (availableWidth / aspectRatio <= availableHeight) {
-            newWidth = availableWidth;
-            newHeight = availableWidth / aspectRatio;
-          } else {
-            newHeight = availableHeight;
-            newWidth = availableHeight * aspectRatio;
-          }
-          
-          newWidth = Math.max(newWidth, 400);
-          newHeight = Math.max(newHeight, 300);
-          
-          canvas.width = Math.floor(newWidth);
-          canvas.height = Math.floor(newHeight);
-          
-          canvas.style.width = Math.floor(newWidth) + 'px';
-          canvas.style.height = Math.floor(newHeight) + 'px';
-          
-          console.log('Canvas resized to:', Math.floor(newWidth) + 'x' + Math.floor(newHeight));
-        }
-        
-        window.onerror = function(message, source, lineno, colno, error) {
-          console.error('Simulation Error:', message, 'Line:', lineno);
-          if (statusEl) {
-            statusEl.className = 'status error';
-            statusEl.textContent = 'Script Error';
-          }
-          return true;
-        };
-        
-        setTimeout(() => {
-          const canvas = document.querySelector('canvas');
-          if (canvas) {
-            console.log('Canvas found, original size:', canvas.width + 'x' + canvas.height);
-            
-            resizeCanvas();
-            
-            canvas.style.display = 'block';
-            canvas.style.margin = '0 auto';
-            canvas.style.cursor = 'pointer';
-            
-            if (statusEl && !${simulationData.contentWarning}) {
-              statusEl.className = 'status loading';
-              statusEl.textContent = 'Loading simulation...';
-            }
-            
-            executeSimulation();
-          } else {
-            console.error('Canvas element not found');
-            if (statusEl) {
-              statusEl.className = 'status error';
-              statusEl.textContent = 'Canvas not found';
-            }
-          }
-        }, 100);
-        
-        function executeSimulation() {
-          try {
-            ${simulationData.jsCode}
-            
-            ${
-              !simulationData.contentWarning
-                ? `
-            setTimeout(() => {
-              if (statusEl) {
-                statusEl.className = 'status success';
-                statusEl.textContent = 'Interactive';
-                setTimeout(() => {
-                  statusEl.style.opacity = '0.6';
-                }, 2000);
-              }
-            }, 1000);
-            `
-                : ""
-            }
-            
-          } catch (error) {
-            console.error('Execution Error:', error);
-            if (statusEl) {
-              statusEl.className = 'status error';
-              statusEl.textContent = 'Error: ' + error.message;
-            }
-          }
-        }
-        
-        window.addEventListener('resize', () => {
-          setTimeout(resizeCanvas, 100);
-        });
-      </script>
-    </body>
-    </html>
-  `,
-      [
-        simulationData.canvasHtml,
-        simulationData.jsCode,
-        simulationData.contentWarning,
-      ]
-    );
-
-    return (
-      <iframe
-        className="w-full h-full border-0"
-        title="Interactive Simulation"
-        sandbox="allow-scripts"
-        scrolling="no"
-        srcDoc={iframeContent}
-        style={{
-          overflow: "hidden",
-          border: "none",
-          width: "100%",
-          height: "100%",
-        }}
-      />
-    );
-  }
-);
 
 export default function Demo(): JSX.Element {
   const {
@@ -894,7 +370,7 @@ export default function Demo(): JSX.Element {
   };
 
   return (
-    <ErrorBoundary
+    <DemoErrorBoundary
       fallback={
         <div className="text-red-500 p-4">
           Something went wrong. Please refresh the page.
@@ -922,41 +398,18 @@ export default function Demo(): JSX.Element {
                 </div>
 
                 {showContentWarning && (
-                  <ContentWarningDisplay
+                  <ContentWarning
                     warningMessage={contentWarningMessage}
                     onDismiss={handleContentWarningDismiss}
                   />
                 )}
 
-                {!isDeveloper && isTokenLimitReached && (
-                  <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-2">
-                    <div className="flex items-center space-x-1 mb-1">
-                      <AlertTriangle className="w-3 h-3 text-red-400" />
-                      <div className="text-red-400 font-medium text-xs">
-                        Token Limit
-                      </div>
-                    </div>
-                    <div className="text-red-300 text-xs">
-                      Used {tokenUsage}/{TOKEN_LIMIT} tokens.
-                    </div>
-                  </div>
-                )}
-
-                {!isDeveloper &&
-                  !isTokenLimitReached &&
-                  tokenUsage > TOKEN_LIMIT * 0.8 && (
-                    <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-2">
-                      <div className="flex items-center space-x-1 mb-1">
-                        <AlertTriangle className="w-3 h-3 text-yellow-400" />
-                        <div className="text-yellow-400 font-medium text-xs">
-                          Warning
-                        </div>
-                      </div>
-                      <div className="text-yellow-300 text-xs">
-                        {tokensRemaining} tokens left.
-                      </div>
-                    </div>
-                  )}
+                <TokenNotices
+                  isDeveloper={isDeveloper}
+                  isTokenLimitReached={isTokenLimitReached}
+                  tokenUsage={tokenUsage}
+                  tokensRemaining={tokensRemaining}
+                />
 
                 <SubjectSelector
                   subject={subject}
@@ -964,79 +417,29 @@ export default function Demo(): JSX.Element {
                   disabled={isTokenLimitReached}
                 />
 
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">
-                    Educational Prompt
-                  </label>
-                  <textarea
-                    value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
-                    placeholder={`Describe a ${subject.toLowerCase()} concept to visualize...`}
-                    disabled={isTokenLimitReached}
-                    className="w-full bg-gray-700 border border-gray-600 rounded-md px-2 py-2 text-white h-28 resize-none text-sm focus:ring-1 focus:ring-yellow-500 focus:border-transparent transition-colors placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"
-                  />
-                  <div className="text-xs text-gray-400 mt-1">
-                    {prompt.length}/500 • {subject} educational content
-                  </div>
-                </div>
+                <PromptInput
+                  subject={subject}
+                  prompt={prompt}
+                  onChange={setPrompt}
+                  disabled={isTokenLimitReached}
+                />
 
-                <button
+                <RunButton
                   onClick={() => handleRunSimulation()}
                   disabled={loading || !prompt.trim() || isTokenLimitReached}
-                  className="w-full bg-yellow-500 text-black py-2 rounded-md hover:bg-yellow-400 transition-colors flex items-center justify-center space-x-1 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm disabled:bg-gray-600 disabled:text-gray-400"
-                >
-                  {loading ? (
-                    <>
-                      <Loader2 className="w-3 h-3 animate-spin" />
-                      <span>Creating...</span>
-                    </>
-                  ) : isTokenLimitReached ? (
-                    <>
-                      <AlertTriangle className="w-3 h-3" />
-                      <span>Limit</span>
-                    </>
-                  ) : (
-                    <>
-                      <Play className="w-3 h-3" />
-                      <span>Generate</span>
-                    </>
-                  )}
-                </button>
+                  isLoading={loading}
+                  isTokenLimitReached={isTokenLimitReached}
+                />
 
                 {simulationData &&
                   !isTokenLimitReached &&
                   !showContentWarning && (
-                    <div className="pt-2 border-t border-gray-700">
-                      <div className="flex items-center space-x-1 mb-1">
-                        <MessageSquare className="w-3 h-3 text-blue-400" />
-                        <label className="text-xs font-medium text-gray-300">
-                          Follow-up
-                        </label>
-                      </div>
-                      <div className="flex space-x-1 mb-2">
-                        <input
-                          type="text"
-                          value={followUpPrompt}
-                          onChange={(e) => setFollowUpPrompt(e.target.value)}
-                          placeholder="Feature coming soon..."
-                          disabled={true}
-                          className="flex-1 bg-gray-700 border border-gray-600 rounded-md px-2 py-1 text-white text-xs focus:ring-1 focus:ring-blue-500 focus:border-transparent transition-colors placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"
-                          onKeyPress={(e) =>
-                            e.key === "Enter" && handleFollowUpSubmit()
-                          }
-                        />
-                        <button
-                          onClick={handleFollowUpSubmit}
-                          disabled={true}
-                          className="bg-gray-600 text-white px-2 py-1 rounded-md transition-colors flex items-center disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          <Send className="w-3 h-3" />
-                        </button>
-                      </div>
-                      <p className="text-xs text-gray-500 italic">
-                        Follow-up feature is still being worked on
-                      </p>
-                    </div>
+                    <FollowUpBox
+                      value={followUpPrompt}
+                      onChange={setFollowUpPrompt}
+                      onSubmit={handleFollowUpSubmit}
+                      disabled={true}
+                    />
                   )}
 
                 {simulationData && (
@@ -1048,27 +451,7 @@ export default function Demo(): JSX.Element {
                   </button>
                 )}
 
-                {error && (
-                  <div className="bg-red-500/10 border border-red-500/20 rounded-md p-2">
-                    <div className="flex items-start space-x-1">
-                      <AlertTriangle className="w-3 h-3 text-red-400 mt-0.5 flex-shrink-0" />
-                      <div className="flex-1">
-                        <div className="text-red-400 font-medium text-xs">
-                          Error
-                        </div>
-                        <div className="text-red-300 text-xs mt-1 break-words leading-tight">
-                          {error}
-                        </div>
-                        <button
-                          onClick={dismissError}
-                          className="text-red-400 hover:text-red-300 text-xs mt-1 underline"
-                        >
-                          Dismiss
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
+                {error && <ErrorBanner error={error} onDismiss={dismissError} />}
               </div>
             </aside>
 
@@ -1107,7 +490,7 @@ export default function Demo(): JSX.Element {
                 )}
 
                 {simulationData ? (
-                  <SimulationIframe simulationData={simulationData} />
+                  <SimulationFrame simulationData={simulationData} />
                 ) : (
                   <div className="h-full flex items-center justify-center p-6">
                     <div className="text-center max-w-md">
@@ -1154,7 +537,7 @@ export default function Demo(): JSX.Element {
               <div className="flex-1 overflow-hidden p-2">
                 {simulationData?.explanation && !showContentWarning ? (
                   <div className="bg-white rounded-lg p-3 shadow-sm border border-gray-200 h-full">
-                    <FormattedExplanation
+                    <ExplanationPanel
                       explanation={simulationData.explanation}
                     />
                   </div>
@@ -1178,6 +561,6 @@ export default function Demo(): JSX.Element {
           </div>
         </main>
       </div>
-    </ErrorBoundary>
+    </DemoErrorBoundary>
   );
 }

--- a/frontend/src/types/demo.ts
+++ b/frontend/src/types/demo.ts
@@ -1,0 +1,15 @@
+export interface SimulationResponse {
+  canvasHtml: string;
+  jsCode: string;
+  explanation: string;
+  usage?: {
+    totalTokens: number;
+  };
+  contentWarning?: boolean;
+  warningMessage?: string;
+}
+
+export interface User {
+  email: string | undefined;
+  id: string;
+}


### PR DESCRIPTION
## Summary
- Split Demo page into modular subcomponents for subject selection, prompt input, token notices, run controls, simulation frame, explanation panel, content warnings, follow-up box, and error banner
- Centralize shared types and subject constants
- Preserve existing visual design and behavior while improving structure
