### PR TITLE
fix: rely on headers for CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ X-Frame-Options: SAMEORIGIN
 
 All other routes retain a restrictive CSP and `X-Frame-Options: DENY`, preventing
 embedding of the primary application.
+
+### CSP inheritance bug
+
+Originally the application also shipped a `<meta http-equiv="Content-Security-Policy">`
+tag inside `index.html`. Because Vercel rewrites every path to `index.html`, this meta
+policy combined with the route-specific headers. As a result the browser treated the
+iframe's document as `about:srcdoc` and enforced the main app's `script-src 'self'`
+directive, blocking the injected simulation script.
+
+The meta tag has been removed so that CSP is controlled exclusively by headers.
+This allows `/sim-frame` to execute inline scripts under its relaxed policy while
+the rest of the application remains locked down.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co; frame-src 'self'; object-src 'none'" />
+    <!--
+      CSP is delivered via Vercel route-specific headers. A meta tag would be
+      applied to every route and combine with those headers, which previously
+      caused the /sim-frame iframe to inherit the main app's strict policy and
+      treat injected scripts as coming from about:srcdoc. Removing the meta tag
+      lets the relaxed CSP for /sim-frame take effect while keeping the rest of
+      the app locked down by headers alone.
+    -->
     <title>MindRender - AI-Powered Simulation Engine</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- remove inline CSP meta tag and rely on route headers so `/sim-frame` can run injected scripts
- document previous about:srcdoc CSP inheritance issue
