### PR TITLE
Fix simulation frame CSP and explanation layout

### DIFF
--- a/frontend/public/sim-frame.html
+++ b/frontend/public/sim-frame.html
@@ -3,102 +3,68 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; font-src 'self'; object-src 'none'; media-src 'self'; frame-src 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'self' data: blob:; font-src data:;" />
     <title>Simulation Frame</title>
     <style>
-      * {
+      html, body {
+        width: 100%;
+        height: 100%;
         margin: 0;
         padding: 0;
-        box-sizing: border-box;
-      }
-      html,
-      body,
-      #root {
-        width: 100vw;
-        height: 100vh;
-        margin: 0;
         overflow: hidden;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+      }
+      body {
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 20px;
-        box-sizing: border-box;
+        background: #fff;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       }
       canvas {
         border: 2px solid #e5e7eb;
         border-radius: 12px;
         background: white;
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-        display: block !important;
-        margin: 0 auto;
-        cursor: pointer;
-        image-rendering: -webkit-optimize-contrast;
-        image-rendering: crisp-edges;
-        image-rendering: pixelated;
+        display: block;
       }
       .status {
         position: fixed;
-        top: 15px;
-        right: 15px;
-        padding: 6px 12px;
+        top: 8px;
+        right: 8px;
+        padding: 4px 8px;
         border-radius: 6px;
         font-size: 11px;
         font-weight: 600;
-        z-index: 1000;
-        backdrop-filter: blur(8px);
-        border: 1px solid rgba(255, 255, 255, 0.3);
-        transition: all 0.3s ease;
-        opacity: 0.9;
-        background: rgba(59, 130, 246, 0.15);
+        background: rgba(59,130,246,0.15);
         color: #1e40af;
-        border-color: rgba(59, 130, 246, 0.4);
-      }
-      .status.success {
-        background: rgba(16, 185, 129, 0.15);
-        color: #059669;
-        border-color: rgba(16, 185, 129, 0.4);
       }
       .status.error {
-        background: rgba(239, 68, 68, 0.15);
+        background: rgba(239,68,68,0.15);
         color: #dc2626;
-        border-color: rgba(239, 68, 68, 0.4);
       }
     </style>
   </head>
   <body>
-    <div class="status" id="status">Initializing...</div>
     <div id="root"></div>
+    <div id="status" class="status">Initializing...</div>
     <script>
+      let allowedOrigin = null;
       const statusEl = document.getElementById('status');
-      
+
       function resizeCanvas() {
         const canvas = document.querySelector('canvas');
         if (!canvas) return;
-        
-        // Get device pixel ratio for HiDPI support
+
         const dpr = window.devicePixelRatio || 1;
-        
-        // Get actual original dimensions from the canvas or use defaults
         const originalWidth = canvas.getAttribute('data-original-width') || canvas.width || 800;
         const originalHeight = canvas.getAttribute('data-original-height') || canvas.height || 600;
-        
-        // Store original dimensions for future reference
         if (!canvas.getAttribute('data-original-width')) {
           canvas.setAttribute('data-original-width', originalWidth);
           canvas.setAttribute('data-original-height', originalHeight);
         }
-        
         const aspectRatio = originalWidth / originalHeight;
-        
-        // Use full iframe dimensions minus padding
-        const availableWidth = window.innerWidth - 40; // 20px padding on each side
-        const availableHeight = window.innerHeight - 40; // 20px padding top/bottom
-        
+        const availableWidth = window.innerWidth - 40;
+        const availableHeight = window.innerHeight - 40;
         let displayWidth, displayHeight;
-        
-        // Calculate display size while maintaining aspect ratio
         if (availableWidth / aspectRatio <= availableHeight) {
           displayWidth = availableWidth;
           displayHeight = availableWidth / aspectRatio;
@@ -106,165 +72,43 @@
           displayHeight = availableHeight;
           displayWidth = availableHeight * aspectRatio;
         }
-        
-        // Ensure minimum reasonable size
         displayWidth = Math.max(displayWidth, 320);
         displayHeight = Math.max(displayHeight, 240);
-        
-        // Set canvas internal resolution (for crisp rendering)
         const canvasWidth = Math.floor(displayWidth * dpr);
         const canvasHeight = Math.floor(displayHeight * dpr);
-        
         canvas.width = canvasWidth;
         canvas.height = canvasHeight;
-        
-        // Set CSS display size
-        canvas.style.width = Math.floor(displayWidth) + 'px';
-        canvas.style.height = Math.floor(displayHeight) + 'px';
-        
-        // Scale the drawing context to account for device pixel ratio
-        const ctx = canvas.getContext('2d');
-        if (ctx) {
-          ctx.scale(dpr, dpr);
-        }
-        
-        console.log('Canvas resized to:', Math.floor(displayWidth) + 'x' + Math.floor(displayHeight), 'at', dpr + 'x DPR');
-        
-        // Trigger canvas redraw if there's a global redraw function
-        if (typeof window.redrawCanvas === 'function') {
-          window.redrawCanvas();
-        }
-        
-        // Update interactive elements after resize
-        setTimeout(() => {
-          if (typeof window.updateInteractiveElements === 'function') {
-            window.updateInteractiveElements();
-          }
-        }, 50);
+        canvas.style.width = displayWidth + 'px';
+        canvas.style.height = displayHeight + 'px';
       }
-      
-      // Helper function to maintain interactive element coordinates after resize
-      window.updateInteractiveElements = function() {
-        const canvas = document.querySelector('canvas');
-        if (!canvas) return;
-        
-        // Get the canvas bounding rect for coordinate mapping
-        const rect = canvas.getBoundingClientRect();
-        const scaleX = canvas.width / rect.width;
-        const scaleY = canvas.height / rect.height;
-        
-        // Store scale factors globally for interactive elements to use
-        window.canvasScaleX = scaleX;
-        window.canvasScaleY = scaleY;
-        window.canvasRect = rect;
-        
-        console.log('Interactive elements updated - scaleX:', scaleX, 'scaleY:', scaleY);
-      };
-      
-      // Improved resize handling with debouncing
-      let resizeTimeout;
-      window.addEventListener('resize', () => {
-        clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(() => {
-          resizeCanvas();
-          // Ensure any animation loops or interactive handlers are rebound
-          if (typeof window.handleResize === 'function') {
-            window.handleResize();
-          }
-        }, 150);
-      });
-      
-      // Handle orientation changes on mobile
-      window.addEventListener('orientationchange', () => {
-        setTimeout(() => {
-          resizeCanvas();
-        }, 500);
-      });
-      
+
+      window.addEventListener('resize', () => setTimeout(resizeCanvas, 150));
+      window.addEventListener('orientationchange', () => setTimeout(resizeCanvas, 500));
+
       window.addEventListener('message', (event) => {
-        console.log('Received message in iframe:', event.data);
-        const { canvasHtml, jsCode, contentWarning } = event.data || {};
-        if (typeof canvasHtml === 'string' && typeof jsCode === 'string') {
-          console.log('Processing simulation with canvas HTML length:', canvasHtml.length, 'JS code length:', jsCode.length);
-          const root = document.getElementById('root');
-          if (root) {
-            root.innerHTML = canvasHtml;
-            
-            setTimeout(() => {
-              const canvas = root.querySelector('canvas');
-              if (canvas) {
-                console.log('Canvas found, original size:', canvas.width + 'x' + canvas.height);
-                
-                // Store the original dimensions before any resizing
-                if (!canvas.getAttribute('data-original-width')) {
-                  canvas.setAttribute('data-original-width', canvas.width || 800);
-                  canvas.setAttribute('data-original-height', canvas.height || 600);
-                }
-                
-                // Apply initial sizing
-                resizeCanvas();
-                
-                canvas.style.display = 'block';
-                canvas.style.margin = '0 auto';
-                canvas.style.cursor = 'pointer';
-                
-                if (statusEl && !contentWarning) {
-                  statusEl.textContent = 'Loading simulation...';
-                }
-                
-                // Execute the simulation code
-                try {
-                  console.log('Executing simulation JavaScript code...');
-                  const scriptEl = document.createElement('script');
-                  scriptEl.type = 'text/javascript';
-                  scriptEl.textContent = jsCode + `
-                    console.log('Simulation JavaScript executed successfully');
-                    // Update interactive elements after simulation loads
-                    setTimeout(() => {
-                      if (typeof window.updateInteractiveElements === 'function') {
-                        window.updateInteractiveElements();
-                      }
-                    }, 100);
-                  `;
-                  root.appendChild(scriptEl);
-                  console.log('Script element added to DOM');
-                  
-                  // Additional resize after simulation loads to ensure everything fits
-                  setTimeout(() => {
-                    resizeCanvas();
-                    if (statusEl && !contentWarning) {
-                      statusEl.className = 'status success';
-                      statusEl.textContent = 'Interactive';
-                      setTimeout(() => {
-                        statusEl.style.opacity = '0.6';
-                      }, 2000);
-                    }
-                  }, 500);
-                } catch (error) {
-                  console.error('Execution Error:', error);
-                  if (statusEl) {
-                    statusEl.className = 'status error';
-                    statusEl.textContent = 'Error: ' + error.message;
-                  }
-                }
-              } else {
-                console.error('Canvas element not found');
-                if (statusEl) {
-                  statusEl.className = 'status error';
-                  statusEl.textContent = 'Canvas not found';
-                }
-              }
-            }, 100);
+        if (!allowedOrigin) allowedOrigin = event.origin;
+        if (event.origin !== allowedOrigin) return;
+        const { type, canvasHtml, jsCode, contentWarning } = event.data || {};
+        if (type !== 'MINDRENDER_SIM') return;
+        document.getElementById('root').innerHTML = canvasHtml || '';
+        try {
+          const scriptEl = document.createElement('script');
+          scriptEl.textContent = jsCode || '';
+          document.body.appendChild(scriptEl);
+          resizeCanvas();
+          if (!contentWarning) {
+            statusEl.textContent = 'Interactive';
           }
+          window.parent.postMessage({ type: 'MINDRENDER_SIM_READY' }, allowedOrigin);
+        } catch (err) {
+          statusEl.textContent = 'Error: ' + err.message;
+          statusEl.className = 'status error';
         }
       });
-      
-      window.onerror = function(message, source, lineno, colno, error) {
-        console.error('Simulation Error:', message, 'Line:', lineno);
-        if (statusEl) {
-          statusEl.className = 'status error';
-          statusEl.textContent = 'Script Error';
-        }
+
+      window.onerror = function(message) {
+        statusEl.textContent = 'Script Error';
+        statusEl.className = 'status error';
         return true;
       };
     </script>

--- a/frontend/src/components/demo/ExplanationPanel.tsx
+++ b/frontend/src/components/demo/ExplanationPanel.tsx
@@ -66,7 +66,7 @@ const ExplanationPanel = React.memo(({ explanation }: ExplanationPanelProps) => 
   }, [explanation]);
 
   return (
-    <div className="explanation-wrapper">
+    <div className="space-y-2">
       <style>{`
         .explanation-heading {
           font-size: 16px;
@@ -115,33 +115,17 @@ const ExplanationPanel = React.memo(({ explanation }: ExplanationPanelProps) => 
         .explanation-text:last-child {
           margin-bottom: 0;
         }
-        .explanation-content {
-          flex: 1;
-          overflow-y: auto;
-          min-height: 0;
-          padding-bottom: 0;
-        }
-        .explanation-panel {
-          height: 100%;
-          display: flex;
-          flex-direction: column;
-        }
-        .explanation-wrapper {
-          height: 100%;
-          display: flex;
-          flex-direction: column;
-        }
       `}</style>
 
       <div
-        className="explanation-content"
+        className="overflow-auto"
         dangerouslySetInnerHTML={{
           __html: isExpanded ? fullContent : truncatedContent,
         }}
       />
 
       {needsTruncation && (
-        <div className="flex-shrink-0 pt-2 mt-2 border-t border-gray-200">
+        <div className="pt-2 mt-2 border-t border-gray-200">
           <button
             onClick={() => setIsExpanded(!isExpanded)}
             className="text-blue-600 hover:text-blue-800 text-xs font-medium underline focus:outline-none focus:ring-1 focus:ring-blue-500 focus:ring-opacity-50 rounded transition-colors"

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -534,13 +534,11 @@ export default function Demo(): JSX.Element {
                 </div>
               </div>
 
-              <div className="flex-1 overflow-hidden p-2 flex flex-col">
+              <div className="overflow-auto p-2 flex flex-col">
                 {simulationData?.explanation && !showContentWarning ? (
-                  <div className="bg-white rounded-lg shadow-sm border border-gray-200 flex-1 flex flex-col min-h-0">
-                    <div className="p-3 flex-1 flex flex-col min-h-0">
-                      <ExplanationPanel
-                        explanation={simulationData.explanation}
-                      />
+                  <div className="bg-white rounded-lg shadow-sm border border-gray-200">
+                    <div className="p-3">
+                      <ExplanationPanel explanation={simulationData.explanation} />
                     </div>
                   </div>
                 ) : (

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:;"
+          "value": "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'self' data: blob:; font-src data:;"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- Serve simulation through `/sim-frame` HTML with its own CSP and bootloader that communicates via postMessage
- Update iframe component to send typed messages and log readiness
- Simplify explanation panel styles to remove forced height and unused whitespace