### PR TITLE
Serve simulation via external script and fix explanation layout

### DIFF
--- a/frontend/public/sim-frame.html
+++ b/frontend/public/sim-frame.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'self' data: blob:; font-src data:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'self' blob:; img-src data:; connect-src 'self' data: blob:; font-src data:;" />
     <title>Simulation Frame</title>
     <style>
       html, body {
@@ -46,71 +46,6 @@
   <body>
     <div id="root"></div>
     <div id="status" class="status">Initializing...</div>
-    <script>
-      let allowedOrigin = null;
-      const statusEl = document.getElementById('status');
-
-      function resizeCanvas() {
-        const canvas = document.querySelector('canvas');
-        if (!canvas) return;
-
-        const dpr = window.devicePixelRatio || 1;
-        const originalWidth = canvas.getAttribute('data-original-width') || canvas.width || 800;
-        const originalHeight = canvas.getAttribute('data-original-height') || canvas.height || 600;
-        if (!canvas.getAttribute('data-original-width')) {
-          canvas.setAttribute('data-original-width', originalWidth);
-          canvas.setAttribute('data-original-height', originalHeight);
-        }
-        const aspectRatio = originalWidth / originalHeight;
-        const availableWidth = window.innerWidth - 40;
-        const availableHeight = window.innerHeight - 40;
-        let displayWidth, displayHeight;
-        if (availableWidth / aspectRatio <= availableHeight) {
-          displayWidth = availableWidth;
-          displayHeight = availableWidth / aspectRatio;
-        } else {
-          displayHeight = availableHeight;
-          displayWidth = availableHeight * aspectRatio;
-        }
-        displayWidth = Math.max(displayWidth, 320);
-        displayHeight = Math.max(displayHeight, 240);
-        const canvasWidth = Math.floor(displayWidth * dpr);
-        const canvasHeight = Math.floor(displayHeight * dpr);
-        canvas.width = canvasWidth;
-        canvas.height = canvasHeight;
-        canvas.style.width = displayWidth + 'px';
-        canvas.style.height = displayHeight + 'px';
-      }
-
-      window.addEventListener('resize', () => setTimeout(resizeCanvas, 150));
-      window.addEventListener('orientationchange', () => setTimeout(resizeCanvas, 500));
-
-      window.addEventListener('message', (event) => {
-        if (!allowedOrigin) allowedOrigin = event.origin;
-        if (event.origin !== allowedOrigin) return;
-        const { type, canvasHtml, jsCode, contentWarning } = event.data || {};
-        if (type !== 'MINDRENDER_SIM') return;
-        document.getElementById('root').innerHTML = canvasHtml || '';
-        try {
-          const scriptEl = document.createElement('script');
-          scriptEl.textContent = jsCode || '';
-          document.body.appendChild(scriptEl);
-          resizeCanvas();
-          if (!contentWarning) {
-            statusEl.textContent = 'Interactive';
-          }
-          window.parent.postMessage({ type: 'MINDRENDER_SIM_READY' }, allowedOrigin);
-        } catch (err) {
-          statusEl.textContent = 'Error: ' + err.message;
-          statusEl.className = 'status error';
-        }
-      });
-
-      window.onerror = function(message) {
-        statusEl.textContent = 'Script Error';
-        statusEl.className = 'status error';
-        return true;
-      };
-    </script>
+    <script type="module" src="/sim-frame.js"></script>
   </body>
 </html>

--- a/frontend/public/sim-frame.js
+++ b/frontend/public/sim-frame.js
@@ -1,0 +1,65 @@
+let allowedOrigin = null;
+const statusEl = document.getElementById('status');
+
+function resizeCanvas() {
+  const canvas = document.querySelector('canvas');
+  if (!canvas) return;
+  const dpr = window.devicePixelRatio || 1;
+  const originalWidth = canvas.getAttribute('data-original-width') || canvas.width || 800;
+  const originalHeight = canvas.getAttribute('data-original-height') || canvas.height || 600;
+  if (!canvas.getAttribute('data-original-width')) {
+    canvas.setAttribute('data-original-width', originalWidth);
+    canvas.setAttribute('data-original-height', originalHeight);
+  }
+  const aspectRatio = originalWidth / originalHeight;
+  const availableWidth = window.innerWidth - 40;
+  const availableHeight = window.innerHeight - 40;
+  let displayWidth, displayHeight;
+  if (availableWidth / aspectRatio <= availableHeight) {
+    displayWidth = availableWidth;
+    displayHeight = availableWidth / aspectRatio;
+  } else {
+    displayHeight = availableHeight;
+    displayWidth = availableHeight * aspectRatio;
+  }
+  displayWidth = Math.max(displayWidth, 320);
+  displayHeight = Math.max(displayHeight, 240);
+  const canvasWidth = Math.floor(displayWidth * dpr);
+  const canvasHeight = Math.floor(displayHeight * dpr);
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+  canvas.style.width = displayWidth + 'px';
+  canvas.style.height = displayHeight + 'px';
+}
+
+window.addEventListener('resize', () => setTimeout(resizeCanvas, 150));
+window.addEventListener('orientationchange', () => setTimeout(resizeCanvas, 500));
+
+window.addEventListener('message', (event) => {
+  if (!allowedOrigin) allowedOrigin = event.origin;
+  if (event.origin !== allowedOrigin) return;
+  const { type, canvasHtml, jsCode, contentWarning } = event.data || {};
+  if (type !== 'MINDRENDER_SIM') return;
+  document.getElementById('root').innerHTML = canvasHtml || '';
+  try {
+    const blob = new Blob([jsCode || ''], { type: 'text/javascript' });
+    const scriptEl = document.createElement('script');
+    scriptEl.src = URL.createObjectURL(blob);
+    scriptEl.onload = () => URL.revokeObjectURL(scriptEl.src);
+    document.body.appendChild(scriptEl);
+    resizeCanvas();
+    if (!contentWarning) {
+      statusEl.textContent = 'Interactive';
+    }
+    window.parent.postMessage({ type: 'MINDRENDER_SIM_READY' }, allowedOrigin);
+  } catch (err) {
+    statusEl.textContent = 'Error: ' + err.message;
+    statusEl.className = 'status error';
+  }
+});
+
+window.onerror = function () {
+  statusEl.textContent = 'Script Error';
+  statusEl.className = 'status error';
+  return true;
+};

--- a/frontend/src/components/demo/ExplanationPanel.tsx
+++ b/frontend/src/components/demo/ExplanationPanel.tsx
@@ -118,7 +118,6 @@ const ExplanationPanel = React.memo(({ explanation }: ExplanationPanelProps) => 
       `}</style>
 
       <div
-        className="overflow-auto"
         dangerouslySetInnerHTML={{
           __html: isExpanded ? fullContent : truncatedContent,
         }}

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -534,7 +534,7 @@ export default function Demo(): JSX.Element {
                 </div>
               </div>
 
-              <div className="overflow-auto p-2 flex flex-col">
+              <div className="flex-1 p-2 overflow-y-auto">
                 {simulationData?.explanation && !showContentWarning ? (
                   <div className="bg-white rounded-lg shadow-sm border border-gray-200">
                     <div className="p-3">

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'self' data: blob:; font-src data:;"
+          "value": "default-src 'none'; style-src 'unsafe-inline'; script-src 'self' blob:; img-src data:; connect-src 'self' data: blob:; font-src data:;"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- Load simulation iframe from `/sim-frame` without inline scripts
- Permit `blob:` execution via CSP and bootstrap in `sim-frame.js`
- Remove nested overflow containers so explanation panel fills space
